### PR TITLE
add fix for macos and py39

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -49,5 +49,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install Tox
       run: python -m pip install tox
+    - name: Install HDF5 (macOS)
+      run: brew install hdf5 c-blosc
+      if: matrix.os == 'macos-latest'
     - name: Run Tox
       run: tox -v -e ${{ matrix.toxenv }}


### PR DESCRIPTION
## Description

- Installed `hdf5` and `c-blosc` via `homebrew` on `macos` build.
- It's strange that this is required to pass `py39` tests but not for `py37`. Most probably this problem comes from `pytables` wheels, I should open an issue soon.